### PR TITLE
ポートフォリオの編集画面で既存の画像を表示したい #41

### DIFF
--- a/resources/views/layouts/user/app.blade.php
+++ b/resources/views/layouts/user/app.blade.php
@@ -23,7 +23,7 @@
     <div id="app">
         <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
             <div class="container">
-                <a class="navbar-brand" href="{{ url('/') }}">
+                <a class="navbar-brand" href="{{ url('/portfolios') }}">
                     {{ config('app.name', 'Laravel') }}
                 </a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">

--- a/resources/views/user/portfolios/edit.blade.php
+++ b/resources/views/user/portfolios/edit.blade.php
@@ -29,7 +29,8 @@
                     <input type="text" class="form-control" value="{{old('link', $portfolio->link)}}" name="link">
                 </div>
                 <div class="form-group">
-                    <label for="image">画像</label>
+                    <label for="image">変更前の画像</label><br>
+                    <img src="{{ $portfolio->image_path }}" alt="画像" class="my-2">
                     <input type="file" class="form-control-file" id="image" name="image">
                 </div>
                 <button type="submit" class="btn btn-primary">更新する</button>


### PR DESCRIPTION
#issue
#41 
#やったこと
edit に投稿されているポストの画像を表示できるようにしました。
また、ヘッダーのLaravelの遷移先をportfolios.indexに変更しました。
