### PR TITLE
ユーザーはメールアドレスとパスワードのみで新規登録できる。 #82

### DIFF
--- a/app/Http/Controllers/User/Auth/RegisterController.php
+++ b/app/Http/Controllers/User/Auth/RegisterController.php
@@ -64,9 +64,9 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'password' => ['required', 'string', 'min:8'],
         ]);
     }
 
@@ -79,7 +79,6 @@ class RegisterController extends Controller
     protected function create(array $data)
     {
         return User::create([
-            'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);

--- a/app/Http/Controllers/User/Auth/RegisterController.php
+++ b/app/Http/Controllers/User/Auth/RegisterController.php
@@ -64,7 +64,6 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => ['string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'string', 'min:8'],
         ]);

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -15,7 +15,7 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('name');
+            $table->string('name')->nullable();
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');

--- a/resources/views/user/auth/register.blade.php
+++ b/resources/views/user/auth/register.blade.php
@@ -32,15 +32,6 @@
             @csrf
             <div class="form-group row mb-5">
                 <div class="col-md-6">
-                    <label for="name" class="col-form-label">{{ __('お名前') }}</label>
-                    <input id="name" type="text" placeholder="お名前を入力してください" class="form-control @error('name') is-invalid @enderror bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-full py-2 px-4 block w-full appearance-none leading-normal" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus>
-                    @error('name')
-                        <span class="invalid-feedback" role="alert">
-                            <strong>{{ $message }}</strong>
-                        </span>
-                    @enderror
-                </div>
-                <div class="col-md-6">
                     <label for="email" class="col-form-label">{{ __('メールアドレス') }}</label>
                     <input id="email" placeholder="メールアドレスを入力してください" type="email" class="form-control @error('email') is-invalid @enderror bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-full py-2 px-4 block w-full appearance-none leading-normal" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
                     @error('email')
@@ -57,10 +48,6 @@
                             <strong>{{ $message }}</strong>
                         </span>
                     @enderror
-                </div>
-                <div class="col-md-6">
-                    <label for="password-confirm" class="col-form-label">{{ __('パスワード再入力') }}</label>
-                    <input id="password-confirm" placeholder="パスワードを再度入力してください" type="password" class="form-control bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-full py-2 px-4 block w-full appearance-none leading-normal" name="password_confirmation" required autocomplete="new-password">
                 </div>
             </div>
             <div class="form-group row justify-center text-center mb-5">


### PR DESCRIPTION
# やったこと
- [x] 名前なしでも登録できるようにRegisterControllerの'name' => ['required', 'string', 'max:255'],を'name' => ['string', 'max:255'],に変更しました。
- [x] パスワード入力を一回で済むように'password' => ['required', 'string', 'min:8', 'confirmed'],を'password' => ['required', 'string', 'min:8'],に変更しました。
- [x] nameがないとエラーが出たため、'name' => $data['name'],を削除しました。
- [x] nameがないとエラーが出たため、user_table.phpの$table->string('name');を$table->string('name')->nullable();に変更しました。
- [x] register.bladeの名前とパスワード再入力欄のコードを削除しました。
...

# issue番号
- #82 

# 確認したいこと
- このやり方で問題ないでしょうか？