### PR TITLE
GitHubログインをした際に、マイページURLがsocial_accountsに保存できる 

### DIFF
--- a/app/Http/Controllers/User/Auth/LoginController.php
+++ b/app/Http/Controllers/User/Auth/LoginController.php
@@ -132,6 +132,15 @@ class LoginController extends Controller
                 'image'     => $user->avatar,
             ]);
             Auth::login($socialUser, true);
+
+            $socialAccount = SocialAccount::firstOrCreate([
+                'url'         => $user->user['html_url'],
+                'user_id'     => $socialUser->id,
+            ],[
+                'user_id'     => $socialUser->id,
+                'url'         => $user->user['html_url'],
+                'social_type' => SocialType::GITHUB,
+            ]);
         } catch (Exception $e) {
             return redirect()->route('user.login');
         }


### PR DESCRIPTION
# やったこと
- [ ] GitHibログインをした際に、マイページURLをsocila_accountsテーブルに保存できるようにしました。

# issue番号
- #130 

# 確認したいこと
- GitHibログインをした際に、マイページURLをsocila_accountsテーブルに保存される