### PR TITLE
cardの高さ統一、UI変更

### DIFF
--- a/app/Helpers/RoundSentence.php
+++ b/app/Helpers/RoundSentence.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * 文章を丸める
+ * @param String $sentence
+ * @param Int $limit
+ * @param Int $round_num
+ * @return String $sentence
+ */
+function RoundSentence($sentence, $limit, $round_num)
+{
+    if (mb_strlen($sentence) > $limit) {
+        return mb_substr($sentence, 0, $round_num).'...';
+    }else {
+        return $sentence;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
         "classmap": [
             "database/seeds",
             "database/factories"
+        ],
+        "files": [
+            "app/Helpers/RoundSentence.php"
         ]
     },
     "autoload-dev": {

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -50065,8 +50065,8 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(/*! /Users/suzukimasanao/dev/potfy/resources/js/app.js */"./resources/js/app.js");
-module.exports = __webpack_require__(/*! /Users/suzukimasanao/dev/potfy/resources/sass/app.scss */"./resources/sass/app.scss");
+__webpack_require__(/*! /Users/koinoue/docker-lamp-master/code/potfy/resources/js/app.js */"./resources/js/app.js");
+module.exports = __webpack_require__(/*! /Users/koinoue/docker-lamp-master/code/potfy/resources/sass/app.scss */"./resources/sass/app.scss");
 
 
 /***/ })

--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -18,18 +18,17 @@
             @include('layouts.flash-messages')
             <div class="row">
                 @foreach ($portfolios as $portfolio)
-                <div class="col-xl-3 col-md-6 mb-3">
-                    <div class="card shadow transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-105">
+                <div class="col-xl-4 col-md-6 mb-3">
+                    <div class="card shadow transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-105" style="height: 385px;">
                         <a href="{{route('user.portfolios.show',$portfolio->id)}}" class="no-underline hover:no-underline">
                             <img class="card-img-top object-cover h-48 w-full" src="{{ isset($portfolio->image_path) ? $portfolio->image_path : 'https://res.cloudinary.com/dlalfv68e/image/upload/v1598249615/v8ycx2qljsz6u4lzcosm.png' }}" alt="画像の登録はありません">
                             <div class="card-body pb-0">
-                                    <h5 class="card-title ">タイトル：{{ $portfolio->title }}</h5>
-                                    <p class="card-text">内容：{{ $portfolio->description }}</p>
-                                    <p class="card-text">リンク：{{ $portfolio->link }}</p>
+                                <h5 class="card-title font-extrabold text-left">{{ RoundSentence($portfolio->title, 19, 18) }}</h5>
+                                <p class="card-text text-left" style="height: 90px">{!! RoundSentence($portfolio->description, 74, 75) !!}</p>
                             </div>
                         </a>
-                        <a href="{{ route('user.users.show', $portfolio->user_id) }}" class="d-flex justify-content-center align-items-center">
-                            <img src="{{ $portfolio->user->image }}" alt="" class="rounded-circle h-10 p-2">
+                        <a href="{{ route('user.users.show', $portfolio->user_id) }}" class="d-flex justify-content-end align-items-center pr-4 my-2">
+                            <img src="{{ ($portfolio->user->image)?$portfolio->user->image: '/assets/image/android-chrome-192x192.png' }}" alt="" class="rounded-circle h-10 p-2">
                             <h3 class="card-text">{{ $portfolio->user->name }}</h3>
                         </a>
                     </div>
@@ -43,18 +42,17 @@
             <p class="text-lg font-bold mb-3">人気の投稿</p>
             <div class="row mb-3">
                 @foreach ($topPortfolios as $portfolio)
-                <div class="col-xl-3 col-md-6 mb-3">
-                    <div class="card shadow transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-105">
+                <div class="col-xl-4 col-md-6 mb-3">
+                    <div class="card shadow transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-105" style="height: 385px;">
                         <a href="{{route('user.portfolios.show',$portfolio->id)}}" class="no-underline hover:no-underline">
                             <img class="card-img-top object-cover h-48 w-full" src="{{ isset($portfolio->image_path) ? $portfolio->image_path : 'https://res.cloudinary.com/dlalfv68e/image/upload/v1598249615/v8ycx2qljsz6u4lzcosm.png' }}" alt="画像の登録はありません">
                             <div class="card-body pb-0">
-                                    <h5 class="card-title ">タイトル：{{ $portfolio->title }}</h5>
-                                    <p class="card-text">内容：{{ $portfolio->description }}</p>
-                                    <p class="card-text">リンク：{{ $portfolio->link }}</p>
+                                <h5 class="card-title font-extrabold text-left">{{ RoundSentence($portfolio->title, 19, 18) }}</h5>
+                                <p class="card-text text-left" style="height: 90px">{!! RoundSentence($portfolio->description, 74, 75) !!}</p>
                             </div>
                         </a>
-                        <a href="{{ route('user.users.show', $portfolio->user_id) }}" class="d-flex justify-content-center align-items-center">
-                            <img src="{{ $portfolio->user->image }}" alt="" class="rounded-circle h-10 p-2">
+                        <a href="{{ route('user.users.show', $portfolio->user_id) }}" class="d-flex justify-content-end align-items-center pr-4 my-2">
+                            <img src="{{ ($portfolio->user->image)?$portfolio->user->image: '/assets/image/android-chrome-192x192.png' }}" alt="" class="rounded-circle h-10 p-2">
                             <h3 class="card-text">{{ $portfolio->user->name }}</h3>
                         </a>
                     </div>

--- a/resources/views/user/portfolios/index.blade.php
+++ b/resources/views/user/portfolios/index.blade.php
@@ -8,18 +8,17 @@
             @include('layouts.flash-messages')
             <div class="row mb-3">
                 @foreach ($portfolios as $portfolio)
-                <div class="col-xl-3 col-md-6 mb-3">
-                    <div class="card shadow transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-105">
+                <div class="col-xl-4 col-md-6 mb-3">
+                    <div class="card shadow transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-105" style="height: 385px;">
                         <a href="{{route('user.portfolios.show',$portfolio->id)}}" class="no-underline hover:no-underline">
                             <img class="card-img-top object-cover h-48 w-full" src="{{ isset($portfolio->image_path) ? $portfolio->image_path : 'https://res.cloudinary.com/dlalfv68e/image/upload/v1598249615/v8ycx2qljsz6u4lzcosm.png' }}" alt="画像の登録はありません">
                             <div class="card-body pb-0">
-                                    <h5 class="card-title ">タイトル：{{ $portfolio->title }}</h5>
-                                    <p class="card-text">内容：{{ $portfolio->description }}</p>
-                                    <p class="card-text">リンク：{{ $portfolio->link }}</p>
+                                <h5 class="card-title font-extrabold text-left">{{ RoundSentence($portfolio->title, 19, 18) }}</h5>
+                                <p class="card-text text-left" style="height: 90px">{!! RoundSentence($portfolio->description, 74, 75) !!}</p>
                             </div>
                         </a>
-                        <a href="{{ route('user.users.show', $portfolio->user_id) }}" class="d-flex justify-content-center align-items-center">
-                            <img src="{{ $portfolio->user->image }}" alt="" class="rounded-circle h-10 p-2">
+                        <a href="{{ route('user.users.show', $portfolio->user_id) }}" class="d-flex justify-content-end align-items-center pr-4 my-2">
+                            <img src="{{ ($portfolio->user->image)?$portfolio->user->image: '/assets/image/android-chrome-192x192.png' }}" alt="" class="rounded-circle h-10 p-2">
                             <h3 class="card-text">{{ $portfolio->user->name }}</h3>
                         </a>
                     </div>

--- a/resources/views/user/profiles/show.blade.php
+++ b/resources/views/user/profiles/show.blade.php
@@ -26,18 +26,17 @@
             <div class="row text-center">
                 @if (count($portfolios) !== 0)
                 @foreach ($portfolios as $portfolio)
-                <div class="col-xl-3 col-md-6 mb-3">
-                    <div class="card shadow transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-105">
+                <div class="col-xl-4 col-md-6 mb-3">
+                    <div class="card shadow transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-105" style="height: 385px;">
                         <a href="{{route('user.portfolios.show',$portfolio->id)}}" class="no-underline hover:no-underline">
                             <img class="card-img-top object-cover h-48 w-full" src="{{ isset($portfolio->image_path) ? $portfolio->image_path : 'https://res.cloudinary.com/dlalfv68e/image/upload/v1598249615/v8ycx2qljsz6u4lzcosm.png' }}" alt="画像の登録はありません">
                             <div class="card-body pb-0">
-                                    <h5 class="card-title ">タイトル：{{ $portfolio->title }}</h5>
-                                    <p class="card-text">内容：{{ $portfolio->description }}</p>
-                                    <p class="card-text">リンク：{{ $portfolio->link }}</p>
+                                <h5 class="card-title font-extrabold text-left">{{ RoundSentence($portfolio->title, 19, 18) }}</h5>
+                                <p class="card-text text-left" style="height: 90px">{!! RoundSentence($portfolio->description, 74, 75) !!}</p>
                             </div>
                         </a>
-                        <a href="{{ route('user.users.show', $portfolio->user_id) }}" class="d-flex justify-content-center align-items-center">
-                            <img src="{{ $portfolio->user->image }}" alt="" class="rounded-circle h-10 p-2">
+                        <a href="{{ route('user.users.show', $portfolio->user_id) }}" class="d-flex justify-content-end align-items-center pr-4 my-2">
+                            <img src="{{ ($portfolio->user->image)?$portfolio->user->image: '/assets/image/android-chrome-192x192.png' }}" alt="" class="rounded-circle h-10 p-2">
                             <h3 class="card-text">{{ $portfolio->user->name }}</h3>
                         </a>
                     </div>


### PR DESCRIPTION
# やったこと
#### portfolioのcardのUIを調整
- [x] cardの高さを統一
- [x] 文字数の制限。超えるものは'...'でを末尾に表示
- [x] userのnameは右下に表示し、画像がなければロゴを表示する。
...

# issue番号
- #151

# 確認したいこと
- app/Helpesr/に文字数制限の関数を作りましたので基本どのファイルでも読めます！
- merge後が`composer install`でhelper関数を使用できます。
<img width="1791" alt="スクリーンショット 2020-09-13 18 42 39" src="https://user-images.githubusercontent.com/58254300/93015101-a016e580-f5f1-11ea-89ee-8d966801cb76.png">
