### PR TITLE
ユーザー名が登録されていない時に、トップメニューに「ゲスト+ID」で表示をすることができる

### DIFF
--- a/resources/views/layouts/user/nav.blade.php
+++ b/resources/views/layouts/user/nav.blade.php
@@ -30,7 +30,7 @@
 				@else
 					<li class="nav-item dropdown">
 						<a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
-							{{ Auth::user()->name }} <span class="caret"></span>
+						{{  Auth::user()->name ? Auth::user()->name : 'ゲスト' . Auth::id()}} <span class="caret"></span>
 						</a>
 
 						<div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">


### PR DESCRIPTION
# やったこと
- [ ユーザー名が登録されていない時に、トップメニューに「ゲスト+ID」で表示をすることができる]


# issue番号
- # 160

