### PR TITLE
ゲスト状態で、投稿されたポートフォリオカードから、ユーザー詳細に飛ぼうとするとエラーが発生する

### DIFF
--- a/resources/views/user/profiles/show.blade.php
+++ b/resources/views/user/profiles/show.blade.php
@@ -13,7 +13,7 @@
                     <a href="{{ $account->url }}" class="text-blue-500" target="_blank">{{ App\Enums\SocialType::getDescription($account->social_type) }}</a>
                 </p>
             @endforeach
-            @if (Auth::user()->id === $user->id)
+            @if (Auth::id() === $user->id)
                 <a href="{{route('users.edit', $user)}}" class="btn bg-potfyYellow hover:bg-potfyYellowTitle text-white font-bold py-2 px-4 rounded-full mt-4">プロフィールを編集する</a>
             @endif
         </div>


### PR DESCRIPTION
# issue番号
- connects #262 

# やったこと
- [x] ゲスト状態で、投稿されたポートフォリオカードから、ユーザー詳細に飛ぼうとするとエラーが発生するため、Auth::user() から Auth::id() に変更
...